### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ The goal is to find the very best test frameworks for testing AMD modules in bot
 
 ## Mocha
 Mocha is working in the browser. Mocha doesn't come with an assertion library, so I'm using the excellent [chai.js](http://chaijs.com/).
-###Browser Testing
+### Browser Testing
 Open mocha/runner.html in your browser
 
 ## Jasmine


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
